### PR TITLE
Clean up filename string before calling basename

### DIFF
--- a/extraction_server.py
+++ b/extraction_server.py
@@ -35,7 +35,8 @@ class ExfiltrateHandler(tornado.web.RequestHandler):
     EXFIL_PATH = os.path.abspath("./exfiltrated_files/")
 
     def post(self, username, filename):
-
+        
+        filename = filename.replace("/", "")
         filename = os.path.basename(filename)
         raw_data = self.request.body
 


### PR DESCRIPTION
I haven't tested this throughly with other setups but I had to include this line to get it to work for me. 

I cant seem to see a case where filename is not "chat.db/", which when passed into `os.path.basename()` returns nothing. Removing the trailing slash allows basename to return "chat.db". 
